### PR TITLE
vpc-migrate-ipv6: correct cloud-init configuration for dualstack setup

### DIFF
--- a/doc_source/vpc-migrate-ipv6.md
+++ b/doc_source/vpc-migrate-ipv6.md
@@ -419,6 +419,7 @@ Due to a known issue, if you're using RHEL/CentOS 7\.4 with the latest version o
      - type: physical
        name: eth0
        subnets:
+         - type: dhcp
          - type: dhcp6
    ```
 


### PR DESCRIPTION
This is related to the following change in cloud-init:
https://code.launchpad.net/~vkuznets/cloud-init/+git/cloud-init/+merge/343601

Specifying: dhcp6 only now causes DHCPv6-only setup and that's not what most
users want.

Signed-off-by: Vitaly Kuznetsov <vkuznets@redhat.com>

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1558854

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
