### PR TITLE
Miss a service supporting Interface Endpoints

### DIFF
--- a/doc_source/vpc-endpoints.md
+++ b/doc_source/vpc-endpoints.md
@@ -22,6 +22,7 @@ An [interface endpoint](vpce-interface.md) is an elastic network interface with 
 + AWS Service Catalog
 + [Amazon SNS](http://docs.aws.amazon.com/sns/latest/dg/sns-vpc.html)
 + [AWS Systems Manager](http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-setting-up-vpc.html)
++ AWS Elasticsearch
 + [Endpoint services](endpoint-service.md) hosted by other AWS accounts
 + Supported AWS Marketplace partner services
 


### PR DESCRIPTION
AWS Elasticsearch supports Interface Endpoints since [October](https://aws.amazon.com/about-aws/whats-new/2017/10/amazon-elasticsearch-service-announces-support-for-amazon-virtual-private-cloud-vpc/)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
