### PR TITLE
Add missing step for tag modifications

### DIFF
--- a/doc_source/flow-logs-cwl.md
+++ b/doc_source/flow-logs-cwl.md
@@ -77,7 +77,9 @@ You can update an existing role or use the following procedure to create a new r
 
 1. Choose **EC2** as the service to use this role\. For **Use case**, choose **EC2**\. Choose **Next: Permissions**\.
 
-1. On the **Attach permissions policies** page, choose **Next: Review**\.
+1. On the **Attach permissions policies** page, choose **Next: Tags**\.
+
+1. Enter an optional tag to assign to the role\. Choose **Next: Review**\.
 
 1. Enter a name for your role \(for example, `Flow-Logs-Role`\) and optionally provide a description\. Choose **Create role**\.
 

--- a/doc_source/flow-logs-cwl.md
+++ b/doc_source/flow-logs-cwl.md
@@ -77,9 +77,7 @@ You can update an existing role or use the following procedure to create a new r
 
 1. Choose **EC2** as the service to use this role\. For **Use case**, choose **EC2**\. Choose **Next: Permissions**\.
 
-1. On the **Attach permissions policies** page, choose **Next: Tags**\.
-
-1. Enter an optional tag to assign to the role\. Choose **Next: Review**\.
+1. On the **Attach permissions policies** page, choose **Next: Tags**\ and optionally add tags. Choose **Next: Review**\.
 
 1. Enter a name for your role \(for example, `Flow-Logs-Role`\) and optionally provide a description\. Choose **Create role**\.
 


### PR DESCRIPTION
The current flow doesn't take into account the dialog that allows the user to specify tags for the created role.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
