### PR TITLE
Add Glue to Interface Endpoint support list

### DIFF
--- a/doc_source/vpc-endpoints.md
+++ b/doc_source/vpc-endpoints.md
@@ -19,6 +19,7 @@ An [interface endpoint](vpce-interface.md) is an elastic network interface with 
 + [AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/codecommit-and-interface-VPC.html)
 + [AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/vpc-support.html#use-vpc-endpoints-with-codepipeline)
 + [AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/config-VPC-endpoints.html)
++ [AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/vpc-endpoints-s3.html)
 + Amazon EC2 API
 + [Elastic Load Balancing](https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/load-balancer-vpc-endpoints.html)
 + [Amazon Elastic Container Registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/vpc-endpoints.html)

--- a/doc_source/vpc-endpoints.md
+++ b/doc_source/vpc-endpoints.md
@@ -19,7 +19,7 @@ An [interface endpoint](vpce-interface.md) is an elastic network interface with 
 + [AWS CodeCommit](https://docs.aws.amazon.com/codecommit/latest/userguide/codecommit-and-interface-VPC.html)
 + [AWS CodePipeline](https://docs.aws.amazon.com/codepipeline/latest/userguide/vpc-support.html#use-vpc-endpoints-with-codepipeline)
 + [AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/config-VPC-endpoints.html)
-+ [AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/vpc-endpoints-s3.html)
++ [AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/vpc-endpoint.html)
 + Amazon EC2 API
 + [Elastic Load Balancing](https://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/load-balancer-vpc-endpoints.html)
 + [Amazon Elastic Container Registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/vpc-endpoints.html)


### PR DESCRIPTION


*Issue #, if available:*
N/A

*Description of changes:*
Glue now supports AWS Interface Endpoint: https://aws.amazon.com/about-aws/whats-new/2019/06/aws_glue_now_provides_vpc_interface_endpoint/. This pull requests update the list with the link to the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
