### PR TITLE
Update flow-logs-s3.md

### DIFF
--- a/doc_source/flow-logs-s3.md
+++ b/doc_source/flow-logs-s3.md
@@ -92,6 +92,7 @@ If the user creating the flow log owns the bucket, we automatically attach the f
 ```
 
 If the user creating the flow log does not own the bucket, or does not have the `GetBucketPolicy` and `PutBucketPolicy` permissions for the bucket, the flow log creation fails\. In this case, the bucket owner must manually add the above policy to the bucket and specify the flow log creator's AWS account ID\. For more information, see [How Do I Add an S3 Bucket Policy?](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/add-bucket-policy.html) in the *Amazon Simple Storage Service Console User Guide*\. If the bucket receives flow logs from multiple accounts, add a `Resource` element entry to the `AWSLogDeliveryWrite` policy statement for each account\. For example, the following bucket policy allows AWS accounts `123123123123` and `456456456456` to publish flow logs to a folder named `flow-logs` in a bucket named `log-bucket`\.
+Destination S3 Bucket should not have any Encryption enabled, otherwise you will get permission denied error\.
 
 ```
 {


### PR DESCRIPTION
Added note if using Centralized S3 bucket to store VPC Flow Logs from other AWS accounts, your destination bucket should not 
have any Encryption on the bucket.
Otherwise you will get error: 
Access Denied for LogDestination: my-bucket. Please check LogDestination permission.

Looks like Principal Service ` delivery.logs.amazonaws.com` not working with Encrypted buckets in another account.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
