### PR TITLE
Update VPC_Scenario1.md

### DIFF
--- a/doc_source/VPC_Scenario1.md
+++ b/doc_source/VPC_Scenario1.md
@@ -24,7 +24,7 @@ The configuration for this scenario includes the following:
 + A virtual private cloud \(VPC\) with a size /16 IPv4 CIDR block \(example: 10\.0\.0\.0/16\)\. This provides 65,536 private IPv4 addresses\.
 + A subnet with a size /24 IPv4 CIDR block \(example: 10\.0\.0\.0/24\)\. This provides 256 private IPv4 addresses\.
 + An Internet gateway\. This connects the VPC to the Internet and to other AWS services\.
-+ An instance with a private IPv4 address in the subnet range \(example: 10\.0\.0\.6\), which enables the instance to communicate with other instances in the VPC, and an Elastic IPv4 address \(example: 198\.51\.100\.2\), which is a public IPv4 address that enables the instance ability to connect to the Iternet and to be reachable from the Internet\.
++ An instance with a private IPv4 address in the subnet range \(example: 10\.0\.0\.6\), which enables the instance to communicate with other instances in the VPC, and an Elastic IPv4 address \(example: 198\.51\.100\.2\), which is a public IPv4 address that enables the instance to connect to the Internet and to be reached from the Internet\.
 + A custom route table associated with the subnet\. The route table entries enable instances in the subnet to use IPv4 to communicate with other instances in the VPC, and to communicate directly over the Internet\. A subnet that's associated with a route table that has a route to an Internet gateway is known as a *public subnet*\.
 
 For more information about subnets, see [VPCs and Subnets](VPC_Subnets.md)\. For more information about Internet gateways, see [Internet Gateways](VPC_Internet_Gateway.md)\.

--- a/doc_source/VPC_Scenario1.md
+++ b/doc_source/VPC_Scenario1.md
@@ -24,7 +24,7 @@ The configuration for this scenario includes the following:
 + A virtual private cloud \(VPC\) with a size /16 IPv4 CIDR block \(example: 10\.0\.0\.0/16\)\. This provides 65,536 private IPv4 addresses\.
 + A subnet with a size /24 IPv4 CIDR block \(example: 10\.0\.0\.0/24\)\. This provides 256 private IPv4 addresses\.
 + An Internet gateway\. This connects the VPC to the Internet and to other AWS services\.
-+ An instance with a private IPv4 address in the subnet range \(example: 10\.0\.0\.6\), which enables the instance to communicate with other instances in the VPC, and an Elastic IPv4 address \(example: 198\.51\.100\.2\), which is a public IPv4 address that enables the instance to reach the Internet wihout using NAT gateway and to be reached from the Internet\.
++ An instance with a private IPv4 address in the subnet range \(example: 10\.0\.0\.6\), which enables the instance to communicate with other instances in the VPC, and an Elastic IPv4 address \(example: 198\.51\.100\.2\), which is a public IPv4 address that enables the instance ability to connect to the Iternet and to be reachable from the Internet\.
 + A custom route table associated with the subnet\. The route table entries enable instances in the subnet to use IPv4 to communicate with other instances in the VPC, and to communicate directly over the Internet\. A subnet that's associated with a route table that has a route to an Internet gateway is known as a *public subnet*\.
 
 For more information about subnets, see [VPCs and Subnets](VPC_Subnets.md)\. For more information about Internet gateways, see [Internet Gateways](VPC_Internet_Gateway.md)\.

--- a/doc_source/VPC_Scenario1.md
+++ b/doc_source/VPC_Scenario1.md
@@ -24,7 +24,7 @@ The configuration for this scenario includes the following:
 + A virtual private cloud \(VPC\) with a size /16 IPv4 CIDR block \(example: 10\.0\.0\.0/16\)\. This provides 65,536 private IPv4 addresses\.
 + A subnet with a size /24 IPv4 CIDR block \(example: 10\.0\.0\.0/24\)\. This provides 256 private IPv4 addresses\.
 + An Internet gateway\. This connects the VPC to the Internet and to other AWS services\.
-+ An instance with a private IPv4 address in the subnet range \(example: 10\.0\.0\.6\), which enables the instance to communicate with other instances in the VPC, and an Elastic IPv4 address \(example: 198\.51\.100\.2\), which is a public IPv4 address that enables the instance to be reached from the Internet\.
++ An instance with a private IPv4 address in the subnet range \(example: 10\.0\.0\.6\), which enables the instance to communicate with other instances in the VPC, and an Elastic IPv4 address \(example: 198\.51\.100\.2\), which is a public IPv4 address that enables the instance to reach the Internet wihout using NAT gateway and to be reached from the Internet\.
 + A custom route table associated with the subnet\. The route table entries enable instances in the subnet to use IPv4 to communicate with other instances in the VPC, and to communicate directly over the Internet\. A subnet that's associated with a route table that has a route to an Internet gateway is known as a *public subnet*\.
 
 For more information about subnets, see [VPCs and Subnets](VPC_Subnets.md)\. For more information about Internet gateways, see [Internet Gateways](VPC_Internet_Gateway.md)\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* There is a wrong impression that public IP is needed ONLY to be reachable from the Internet, but that's not true. Without public IP, instance on the public subnet will not be able to reach the Internet, not only being not reachable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
