### PR TITLE
Fixed command for allocating Carrier IP

### DIFF
--- a/doc_source/Carrier_Gateway.md
+++ b/doc_source/Carrier_Gateway.md
@@ -158,7 +158,7 @@ If you used the Amazon EC2 console to launch the instance, or you did not use th
    Example
 
    ```
-   aws ec2 allocate-address--address --region us-east-1 --domain vpc --network-border-group us-east-1-wl1-bos-wlz-1
+   aws ec2 allocate-address --region us-east-1 --domain vpc --network-border-group us-east-1-wl1-bos-wlz-1
    ```
 
    Output


### PR DESCRIPTION
*Issue #, if available:*
This command has typo
aws ec2 allocate-address--address --region us-east-1 --domain vpc --network-border-group us-east-1-wl1-bos-wlz-1

*Description of changes:*
Here is the correct command
aws ec2 allocate-address --region us-east-1 --domain vpc --network-border-group us-east-1-wl1-bos-wlz-1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
