### PR TITLE
Update VPC_Subnets.md

### DIFF
--- a/doc_source/VPC_Subnets.md
+++ b/doc_source/VPC_Subnets.md
@@ -78,7 +78,7 @@ The CIDR block of a subnet can be the same as the CIDR block for the VPC \(for a
 
 For example, if you create a VPC with CIDR block `10.0.0.0/24`, it supports 256 IP addresses\. You can break this CIDR block into two subnets, each supporting 128 IP addresses\. One subnet uses CIDR block `10.0.0.0/25` \(for addresses `10.0.0.0` \- `10.0.0.127`\) and the other uses CIDR block `10.0.0.128/25` \(for addresses `10.0.0.128` \- `10.0.0.255`\)\.
 
-There are many tools available to help you calculate subnet CIDR blocks; for example, see [http://www\.subnet\-calculator\.com/cidr\.php](http://www.subnet-calculator.com/cidr.php)\. Also, your network engineering group can help you determine the CIDR blocks to specify for your subnets\.
+There are many tools available to help you calculate and create IPv4 subnet CIDR blocks; for example, see [subnet calculator](https://network00.com/NetworkTools/IPv4VisualSubnetCalculatorCreator)\. Also, your network engineering group can help you determine the CIDR blocks to specify for your subnets.
 
 The first four IP addresses and the last IP address in each subnet CIDR block are not available for you to use, and cannot be assigned to an instance\. For example, in a subnet with CIDR block `10.0.0.0/24`, the following five IP addresses are reserved: 
 + `10.0.0.0`: Network address\.
@@ -179,6 +179,8 @@ You can associate a single IPv6 CIDR block with an existing VPC in your account,
 If you've associated an IPv6 CIDR block with your VPC, you can associate an IPv6 CIDR block with an existing subnet in your VPC, or when you create a new subnet\. A subnet's IPv6 CIDR block is a fixed prefix length of `/64`\.
 
 For example, you create a VPC and specify that you want to associate an Amazon\-provided IPv6 CIDR block with the VPC\. Amazon assigns the following IPv6 CIDR block to your VPC: `2001:db8:1234:1a00::/56`\. You cannot choose the range of IP addresses yourself\. You can create a subnet and associate an IPv6 CIDR block from this range; for example, `2001:db8:1234:1a00::/64`\.
+
+There are some tools available to help you calculate and create IPv6 subnet CIDR blocks; for example, see [subnet calculator](https://network00.com/NetworkTools/IPv6VisualSubnetCalculatorCreator)\. Also, your network engineering group can help you determine the IPv6 CIDR blocks to specify for your subnets.
 
 You can disassociate an IPv6 CIDR block from a subnet, and you can disassociate an IPv6 CIDR block from a VPC\. After you've disassociated an IPv6 CIDR block from a VPC, you cannot expect to receive the same CIDR if you associate an IPv6 CIDR block with your VPC again later\.
 

--- a/doc_source/VPC_Subnets.md
+++ b/doc_source/VPC_Subnets.md
@@ -78,7 +78,7 @@ The CIDR block of a subnet can be the same as the CIDR block for the VPC \(for a
 
 For example, if you create a VPC with CIDR block `10.0.0.0/24`, it supports 256 IP addresses\. You can break this CIDR block into two subnets, each supporting 128 IP addresses\. One subnet uses CIDR block `10.0.0.0/25` \(for addresses `10.0.0.0` \- `10.0.0.127`\) and the other uses CIDR block `10.0.0.128/25` \(for addresses `10.0.0.128` \- `10.0.0.255`\)\.
 
-There are many tools available to help you calculate and create IPv4 subnet CIDR blocks; for example, see [subnet calculator](https://network00.com/NetworkTools/IPv4VisualSubnetCalculatorCreator)\. Also, your network engineering group can help you determine the CIDR blocks to specify for your subnets.
+There are tools available on the internet to help you calculate and create IPv4 subnet CIDR blocks; for example, see [subnet calculator](https://network00.com/NetworkTools/IPv4VisualSubnetCalculatorCreator)\. You can find other tools that suit your needs by searching for terms such as 'subnet calculator' or 'CIDR calculator'. Your network engineering group can also help you determine the CIDR blocks to specify for your subnets.
 
 The first four IP addresses and the last IP address in each subnet CIDR block are not available for you to use, and cannot be assigned to an instance\. For example, in a subnet with CIDR block `10.0.0.0/24`, the following five IP addresses are reserved: 
 + `10.0.0.0`: Network address\.
@@ -180,7 +180,7 @@ If you've associated an IPv6 CIDR block with your VPC, you can associate an IPv6
 
 For example, you create a VPC and specify that you want to associate an Amazon\-provided IPv6 CIDR block with the VPC\. Amazon assigns the following IPv6 CIDR block to your VPC: `2001:db8:1234:1a00::/56`\. You cannot choose the range of IP addresses yourself\. You can create a subnet and associate an IPv6 CIDR block from this range; for example, `2001:db8:1234:1a00::/64`\.
 
-There are some tools available to help you calculate and create IPv6 subnet CIDR blocks; for example, see [subnet calculator](https://network00.com/NetworkTools/IPv6VisualSubnetCalculatorCreator)\. Also, your network engineering group can help you determine the IPv6 CIDR blocks to specify for your subnets.
+There are tools available on the internet to help you calculate and create IPv6 subnet CIDR blocks; for example, see [subnet calculator](https://network00.com/NetworkTools/IPv6VisualSubnetCalculatorCreator)\. You can find other tools that suit your needs by searching for terms such as 'IPv6 subnet calculator' or 'IPv6 CIDR calculator'. Your network engineering group can also help you determine the IPv6 CIDR blocks to specify for your subnets.
 
 You can disassociate an IPv6 CIDR block from a subnet, and you can disassociate an IPv6 CIDR block from a VPC\. After you've disassociated an IPv6 CIDR block from a VPC, you cannot expect to receive the same CIDR if you associate an IPv6 CIDR block with your VPC again later\.
 


### PR DESCRIPTION
*Description of changes:*
Updated reference to the tool for calculating **and creating** IPv4 subnet CIDR blocks, the previously linked tool allowed only for calculation and has no feature for creating subnets. Moreover, that's an HTTP only website, doesn't look nice when user sees - "Your connection to this site is not secure " on a website linked by Amazon.
Provided similar reference for IPv6 and guided the reader to check with their network engineering group to determine the IPv6 CIDR block for their subnet, similar to the way it has been said for IPv4 CIDR block.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
