### PR TITLE
The vpc console link broken

### DIFF
--- a/doc_source/add-endpoint-service-permissions.md
+++ b/doc_source/add-endpoint-service-permissions.md
@@ -13,7 +13,7 @@ If you set permission to "anyone can access" and you set the acceptance model to
 
 **To add or remove permissions using the console**
 
-1. Open the Amazon VPC console at [https://console\.aws\.amazon\.com/vpc/](https://console.aws.amazon.com/vpc/)\.
+1. Open the Amazon VPC console at [https://console\.aws\.amazon\.com/vpc/](https://console.aws.amazon.com/vpc/home)\.
 
 1. In the navigation pane, choose **Endpoint Services** and select your endpoint service\.
 


### PR DESCRIPTION
The VPC console link is broken(returns a 404) changed the link from https://console.aws.amazon.com/vpc/ to https://console.aws.amazon.com/vpc/home.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
