### PR TITLE
Endpoint Service DNS Validation: Change example to comply with current verification values

### DIFF
--- a/doc_source/endpoint-services-dns-validation.md
+++ b/doc_source/endpoint-services-dns-validation.md
@@ -9,11 +9,11 @@ When you initiate domain ownership verification using the Amazon VPC Console or 
 
 | Domain verification name | Type | Domain verification value | 
 | --- | --- | --- | 
-|  \_vpce:aksldja21i1  |  TXT  |  vpce:asjdakjshd78126eu21  | 
+|  \_aksldja21i1  |  TXT  |  vpce:asjdakjshd78126eu21  | 
 
 Add a TXT record to your domain's DNS server using the specified **Domain verification name** and **Domain verification value**\. The domain ownership verification is complete when we detect the existence of the TXT record in your domain's DNS settings\.
 
-If your DNS provider does not allow DNS record names to contain underscores, you can omit *\_aksldja21i1* from the **Domain verification name**\. In that case, for the preceding example, the TXT record name would be myexampleservice\.com instead of *\_vpce:aksldja21i1\.myexampleservice\.com*\.
+If your DNS provider does not allow DNS record names to contain underscores, you can omit *\_aksldja21i1* from the **Domain verification name**\. In that case, for the preceding example, the TXT record name would be myexampleservice\.com instead of *\_aksldja21i1\.myexampleservice\.com*\.
 
 ## Adding a TXT record to your domain's DNS server<a name="add-dns-txt-record"></a>
 


### PR DESCRIPTION
*Description of changes:*
In the example provided, the Domain name doesn't start with `_vpce:someval`. Instead it starts with `_someval`. For the value, it is correct (it is prefixed with `vpce:`). 

This confused me a little, as the text below was partly consistent.

Please correct me, if I'm wrong! :)