### PR TITLE
Update flow-logs.md

### DIFF
--- a/doc_source/flow-logs.md
+++ b/doc_source/flow-logs.md
@@ -74,7 +74,7 @@ The aggregation interval is the period of time during which a particular flow is
 
 When a network interface is attached to a [Nitro\-based instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances), the aggregation interval is always 1 minute or less, regardless of the specified maximum aggregation interval\.
 
-After data is captured within an aggregation interval, it takes additional time to process and publish the data to CloudWatch Logs or Amazon S3\. This additional time could be around 5 minutes to publish to CloudWatch Logs, and around 10 minutes to publish to Amazon S3\. The flow logs service delivers within this additional time in a best effort manner\. In some cases, your logs might be delayed beyond the 5 to 10 minutes additional time mentioned previously\.
+After data is captured within an aggregation interval, it takes additional time to process and publish the data to CloudWatch Logs or Amazon S3\. This delay interval is typically around 5 minutes to publish to CloudWatch Logs, and around 10 minutes to publish to Amazon S3\. The flow logs service delivers within these delay intervals in a best effort manner\. In some cases, your logs will be published after a delay period that exceeds 5 or 10 minutes\.
 
 ### Default format<a name="flow-logs-default"></a>
 

--- a/doc_source/flow-logs.md
+++ b/doc_source/flow-logs.md
@@ -74,7 +74,7 @@ The aggregation interval is the period of time during which a particular flow is
 
 When a network interface is attached to a [Nitro\-based instance](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances), the aggregation interval is always 1 minute or less, regardless of the specified maximum aggregation interval\.
 
-After data is captured within an aggregation interval, it takes additional time to process and publish the data to CloudWatch Logs or Amazon S3\. This delay interval is typically around 5 minutes to publish to CloudWatch Logs, and around 10 minutes to publish to Amazon S3\. The flow logs service delivers within these delay intervals in a best effort manner\. In some cases, your logs will be published after a delay period that exceeds 5 or 10 minutes\.
+After data is captured within an aggregation interval, it takes additional time to process and publish the data to CloudWatch Logs or Amazon S3\. The flow log service typically delivers logs to CloudWatch Logs in about 5 minutes and to Amazon S3 in about 10 minutes\. However, log delivery is on a best effort basis, and your logs might be delayed beyond the typical delivery time\.
 
 ### Default format<a name="flow-logs-default"></a>
 


### PR DESCRIPTION
I made some suggestions for the paragraph below.   I think "delay interval" is a better description than "additional time". "Typically" is more appropriate than the word "could".  

If these changes are not accepted, I suggest that an "of" is added to the last sentence in the paragraph - 
In some cases, your logs might be delayed beyond the 5 to 10 minutes "of" additional time mentioned previously.

"After data is captured within an aggregation interval, it takes additional time to process and publish the data to CloudWatch Logs or Amazon S3. This additional time could be around 5 minutes to publish to CloudWatch Logs, and around 10 minutes to publish to Amazon S3. The flow logs service delivers within this additional time in a best effort manner. In some cases, your logs might be delayed beyond the 5 to 10 minutes additional time mentioned previously."

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
