### PR TITLE
Maximum number of prefix list entries is not specified

### DIFF
--- a/doc_source/amazon-vpc-limits.md
+++ b/doc_source/amazon-vpc-limits.md
@@ -42,7 +42,8 @@ Each EC2 instance limits the number of packets that can be sent to the Amazon Ro
 
 | Resource | Default | Comments | 
 | --- | --- | --- | 
-|  Prefix lists per Region  |  100  |  \-  | 
+|  Prefix lists per Region  |  100  |  \-  |
+|  Maximum number of entries per prefix list   |  1,000  |  \-  |
 |  Versions per prefix list  |  1,000  |  \-  | 
 |  References to a prefix list per resource type  |  5,000  |  This quota applies per resource type that can reference a prefix list\. For example, you can have 5,000 references to a prefix list across all of your security groups plus 5,000 references to a prefix list across all of your subnet route tables\. If you share a prefix list with other AWS accounts, the other accounts' references to your prefix list count toward this quota\.  | 
 


### PR DESCRIPTION
Maximum number of entries for the managed prefix lists is not specified. When you try to put value more than 1,000 in the console it will provide an error `Must specify a max size between 1 and 1000`

*Issue #, if available:*

*Description of changes:*
Added definition for maximum number of prefix list entries.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
