### PR TITLE
Added ListBucket perm to avoid HeadBucket AccessDenied Events

### DIFF
--- a/doc_source/flow-logs-s3.md
+++ b/doc_source/flow-logs-s3.md
@@ -80,10 +80,10 @@ The following bucket policy gives the flow log permission to publish logs to it\
             "Condition": {"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}
         },
         {
-            "Sid": "AWSLogDeliveryAclCheck",
+            "Sid": "AWSLogDeliveryCheck",
             "Effect": "Allow",
             "Principal": {"Service": "delivery.logs.amazonaws.com"},
-            "Action": "s3:GetBucketAcl",
+            "Action": ["s3:GetBucketAcl", "s3:ListBucket"],
             "Resource": "arn:aws:s3:::bucket_name"
         }
     ]
@@ -110,10 +110,10 @@ If the user creating the flow log does not own the bucket, or does not have the 
             "Condition": {"StringEquals": {"s3:x-amz-acl": "bucket-owner-full-control"}}
         },
         {
-            "Sid": "AWSLogDeliveryAclCheck",
+            "Sid": "AWSLogDeliveryCheck",
             "Effect": "Allow",
             "Principal": {"Service": "delivery.logs.amazonaws.com"},
-            "Action": "s3:GetBucketAcl",
+            "Action": ["s3:GetBucketAcl", "s3:ListBucket"],
             "Resource": "arn:aws:s3:::log-bucket"
         }
     ]


### PR DESCRIPTION

*Issue #, if available:*

Related to - https://forums.aws.amazon.com/thread.jspa?threadID=305456

*Description of changes:*

Similar to the issue described on the forum, `delivery.logs.amazonaws.com` service fails to perform `HeadBucket` action on the bucket. The problem is eliminated by allowing `ListBucket` action.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
