### PR TITLE
Fix typo in vpc-nat-gateway.md

### DIFF
--- a/doc_source/vpc-nat-gateway.md
+++ b/doc_source/vpc-nat-gateway.md
@@ -117,7 +117,7 @@ The following are example use cases for public and private NAT gateways\.
 
 You can use a public NAT gateway to enable instances in a private subnet to send outbound traffic to the internet, but the internet cannot establish connections to the instances\.
 
-The following diagram illustrates the architecture for this use case\. The public subnet in Availability Zone A contains the NAT gateway\. The private subnet in Availability Zone B contains instances\. The router sends internet bound traffic from the instances in the private subnet to the NAT gateway\. The NAT gateway sends the traffic to the internet gateway, using the elastic IP address for the NAT gateway as the source IP address\.
+The following diagram illustrates the architecture for this use case\. The public subnet in Availability Zone A contains the NAT gateway\. The private subnet in Availability Zone B contains instances\. The router sends internet bound traffic from the instances in the private subnet to the NAT gateway\. The NAT gateway sends the traffic to the internet gateway, using the private IP address for the NAT gateway as the source IP address\.
 
 ![\[A VPC with public and private subnets and a NAT gateway\]](http://docs.aws.amazon.com/vpc/latest/userguide/images/nat-gateway-diagram.png)
 


### PR DESCRIPTION
The NAT gateway uses its private address as the source when sending to the IGW, not the EIP of the NAT gateway.

Changed wording - "elastic" to "private"


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
