### PR TITLE
Fix typo and update button names

### DIFF
--- a/doc_source/working-with-vpcs.md
+++ b/doc_source/working-with-vpcs.md
@@ -155,7 +155,7 @@ The Amazon Virtual Private Cloud Console provides the status of the request at t
 
 1. Select the VPC, and choose **Actions**, **Edit CIDRs**\.
 
-1. Choose **Add IPv4 CIDR**, and enter the CIDR block to add; for example, `10.2.0.0/16`\. Choose the tick icon\.
+1. Choose **Add new IPv4 CIDR**, and enter the CIDR block to add; for example, `10.2.0.0/16`\. Choose the tick icon\.
 
 1. Choose **Close**\.
 
@@ -179,9 +179,7 @@ You can associate an IPv6 CIDR block with any existing VPC\. The VPC must not ha
 
 1. Select your VPC, choose **Actions**, **Edit CIDRs**\.
 
-1. Choose **Add IPv6 CIDR**\. 
-
-1. Choose **Add IPv6 CIDR**\. 
+1. Choose **Add new IPv6 CIDR**\.
 
 1. For **IPv6 CIDR block**, choose one of the following, and then choose **Select CIDR**:
    + **Amazon\-provided IPv6 CIDR block**: Requests an IPv6 CIDR block from Amazon's pool of IPv6 addresses\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR provides two editorial fixes:

1. There is currently a bullet point `Choose **Add IPv6 CIDR**\.` which is repeated twice:
    
![image](https://user-images.githubusercontent.com/13256236/135257393-29ebf001-f90f-47e6-bfe8-cb93d11d9324.png)

The suggested change removes the repetition, automatically renumbers all the bullet points and displays it like this (from my local rendering):

![image](https://user-images.githubusercontent.com/13256236/135257699-6d6c4c96-0dc5-419a-b940-5a93e3615979.png)
 
2. The buttons to add IPv4 and IPv6 CIDR blocks are actually called `Add new IPv4 CIDR` and `Add new IPv6 CIDR` as shown in the AWS console:

![image](https://user-images.githubusercontent.com/13256236/135258075-f4404d96-9fd9-4309-9452-792c7d9c5610.png)

The suggested change updates the name of these buttons.

Please note that the last change is just a line feed at the end of the file (I'm editing the file on Linux).   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
