### PR TITLE
Update flow-logs.md

### DIFF
--- a/doc_source/flow-logs.md
+++ b/doc_source/flow-logs.md
@@ -36,9 +36,9 @@ In the following example, you create a flow log \(`fl-aaa`\) that captures accep
 
 ![\[Flow logs for a subnet and an instance\]](http://docs.aws.amazon.com/vpc/latest/userguide/images/flow-logs-diagram.png)
 
-After you've created a flow log, it can take several minutes to begin collecting and publishing data to the chosen destinations\. Flow logs do not capture real\-time log streams for your network interfaces\. For more information, see [Create a flow log](working-with-flow-logs.md#create-flow-log)\. 
+After you create a flow log, it can take several minutes to begin collecting and publishing data to the chosen destinations\. Flow logs do not capture real\-time log streams for your network interfaces\. For more information, see [Create a flow log](working-with-flow-logs.md#create-flow-log)\. 
 
-If you launch more instances into your subnet after you've created a flow log for your subnet or VPC, a new log stream \(for CloudWatch Logs\) or log file object \(for Amazon S3\) is created for each new network interface\. This occurs as soon as any network traffic is recorded for that network interface\.
+If you launch a new instance into your subnet after you've created a flow log for your subnet or VPC, a new log stream \(for CloudWatch Logs\) or log file object \(for Amazon S3\) is created as soon as any network traffic is recorded for that network interface\.
 
 You can create flow logs for network interfaces that are created by other AWS services, such as:
 + Elastic Load Balancing

--- a/doc_source/flow-logs.md
+++ b/doc_source/flow-logs.md
@@ -38,7 +38,7 @@ In the following example, you create a flow log \(`fl-aaa`\) that captures accep
 
 After you create a flow log, it can take several minutes to begin collecting and publishing data to the chosen destinations\. Flow logs do not capture real\-time log streams for your network interfaces\. For more information, see [Create a flow log](working-with-flow-logs.md#create-flow-log)\. 
 
-If you launch a new instance into your subnet after you've created a flow log for your subnet or VPC, a new log stream \(for CloudWatch Logs\) or log file object \(for Amazon S3\) is created as soon as any network traffic is recorded for that network interface\.
+If you launch an instance into your subnet after you create a flow log for your subnet or VPC, we create a log stream \(for CloudWatch Logs\) or log file object \(for Amazon S3\) for the new network interface as soon as there is network traffic for the network interface\.
 
 You can create flow logs for network interfaces that are created by other AWS services, such as:
 + Elastic Load Balancing


### PR DESCRIPTION
"After you create a flow log" is better than "After you've created a flow log". Staying in the present tense is always best. 
The phrase "for that network interface" doesn't make sense when you are talking about multiple network interfaces.  The word "that" is problem. 
I used the singular "instance" to simplify the sentence, the reader can easily infer that the activity applies to all new instances. 

Thank you for taking the time to review my proposed changes. I think my first suggestion is mainly a preference while the second suggestion addresses a legitimate grammar issue with the word "that".

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
