### PR TITLE
Fix typo in middlebox routing example

### DIFF
--- a/doc_source/internet-gateway-subnet.md
+++ b/doc_source/internet-gateway-subnet.md
@@ -53,7 +53,7 @@ When you use the middlebox routing wizard, the following tags are associated wit
 
 ## Subnet route table<a name="internet-gateway-subnet-route-table"></a>
 
-The route table for the middlebox subnet \(Subnet C\) contains the following routes:
+The route table for the destination subnet \(Subnet B\) contains the following routes:
 
 
 | Destination | Target | Purpose | 


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
